### PR TITLE
Add option for rubout and clear comment ambiguity

### DIFF
--- a/pcb2gcode/millproject
+++ b/pcb2gcode/millproject
@@ -25,7 +25,7 @@ cut-feed = 120
 cut-speed = 20000
 cut-infeed = 4
 bridges = 1
-# Für einseitige Platinen diese Zeile einkommentieren:
+# Für einseitige Platinen diese Zeile unkommentieren:
 # cut-front = yes
 
 # Für rubout (unnötiges Kupfer entfernen) diese Zeile unkommentieren:

--- a/pcb2gcode/millproject
+++ b/pcb2gcode/millproject
@@ -27,3 +27,6 @@ cut-infeed = 4
 bridges = 1
 # Für einseitige Platinen diese Zeile einkommentieren:
 # cut-front = yes
+
+# Für rubout (unnötiges Kupfer entfernen) diese Zeile unkommentieren:
+# extra-passes = 10


### PR DESCRIPTION
This commit add an option for rubout of unnecessary copper and clears a minor ambiguity in the comment above.
